### PR TITLE
Fix compute() to rollback state on failure

### DIFF
--- a/imdlib/core.py
+++ b/imdlib/core.py
@@ -283,17 +283,25 @@ class IMD(Compute):
             Modified IMD object with computed climatic indices
         """
 
-        self.computed = True
+        # method must be set before dispatch (anu_trend reads it);
+        # metadata must be set before dispatch (spi/spei override long_name)
         self.method = method
-        self.scale = scale
-        # Apply base metadata from registry before compute,
-        # so compute functions (e.g. spi) can override with dynamic values
+        saved_meta = (self.var_name, self.var_units, self.var_long_name)
         if method in VAR_METADATA:
             meta = VAR_METADATA[method]
             self.var_name = meta['var_name']
             self.var_units = meta['units']
             self.var_long_name = meta['long_name']
-        return super().compute(method, scale, **kwargs)
+        try:
+            result = super().compute(method, scale, **kwargs)
+        except Exception:
+            # Rollback — keep object usable after failed compute
+            self.method = None
+            self.var_name, self.var_units, self.var_long_name = saved_meta
+            raise
+        self.computed = True
+        self.scale = scale
+        return result
 
     def _monthly_aggregate(self):
         """


### PR DESCRIPTION
## Summary

- `compute()` was setting `self.computed=True` and `self.scale` **before** `super().compute()`. If the compute function raised, the object was left in an inconsistent state where `get_xarray()` would silently produce nonsense (e.g. 365 monthly time points spanning to year 2048 for what's actually daily data).
- Now `self.computed` and `self.scale` are set **only after** successful computation. `self.method` and metadata are set before dispatch (required by `anu_trend` and `spi`/`spei`), but rolled back on failure via try/except.

### Before (failure leaves object broken)
```python
data = imd.open_data('rain', 2018, 2018, 'yearwise')
try:
    data.compute('dr', 'M')  # fails — dr not available on monthly scale
except: pass

ds = data.get_xarray()
ds.time[-1]  # → 2048-05-31  (nonsense, no error)
```

### After (failure leaves object clean)
```python
data = imd.open_data('rain', 2018, 2018, 'yearwise')
try:
    data.compute('dr', 'M')  # fails — dr not available on monthly scale
except: pass

ds = data.get_xarray()
ds.time[-1]  # → 2018-12-31  (correct, object still usable)
data.compute('cdd', 'A')    # retry works
```

## Test plan

- [x] 26/26 existing tests pass
- [x] Failed compute leaves object clean (computed=False, var_name/units/long_name restored)
- [x] Successful compute works as before (CDD, SPI, trends, all indices)
- [x] SPI/SPEI timescale override still works (metadata set before dispatch)
- [x] Trend indices still work (self.method set before dispatch)
- [x] Fail-then-retry: object recovers, second compute succeeds